### PR TITLE
Use luaL_checkinteger() consistently

### DIFF
--- a/lua-mosquitto.c
+++ b/lua-mosquitto.c
@@ -539,7 +539,7 @@ static int ctx_threaded_set(lua_State *L)
 static int ctx_option(lua_State *L)
 {
 	ctx_t *ctx = ctx_check(L, 1);
-	enum mosq_opt_t option = luaL_checkint(L, 2);
+	enum mosq_opt_t option = luaL_checkinteger(L, 2);
 	int type = lua_type(L, 3);
 	int rc;
 


### PR DESCRIPTION
Lua 5.5 (latest stable) dropped the luaL_checkint() alias (which just passed it to luaL_checkinteger() anyway). Since this code already uses luaL_checkinteger() once below, I've just changed this invocation of the old name to the new one.